### PR TITLE
Player Pagination Descriptor Bug Fix

### DIFF
--- a/src/styles/Players.scss
+++ b/src/styles/Players.scss
@@ -244,12 +244,12 @@
         color: #fff;
         font-size: 14px;
         margin-bottom: 25px;
-      
+    
         .pagination {
             display: flex;
             justify-content: space-between;
             align-items: center;
-      
+    
             .page-nav {
                 display: flex;
                 justify-content: center;
@@ -258,7 +258,7 @@
                 left: 50%;
                 transform: translateX(-50%);
                 z-index: 1;
-      
+
                 button {
                     background-color: #444;
                     color: #fff;
@@ -282,13 +282,13 @@
                 margin: 0 10px;
                 }
             }
-      
+    
             .page-size {
                 display: flex;
                 align-items: center;
                 margin-left: auto;
                 margin-bottom: 4.8px;
-      
+
                 select {
                     background-color: #444;
                     color: #fff;
@@ -323,13 +323,14 @@
                 }
             }
         }
-
+    
         .pagination-info {
+            position: absolute;
+            width: 100%;
             text-align: center;
-            margin-top: 10px;
-            color: #fff;
-            font-size: 12px;
+            bottom: -10px;
             color: #999;
+            font-size: 12px;
         }
-    }               
+    }
 }


### PR DESCRIPTION
Previously, for 1000px+ pixel width screens, the player pagination info descriptor was beside the "Show _n_ rows" button rather than on a new line below it. This change fixes the bug and formats the descriptor properly.