### PR TITLE
Mobile Landing Page UI improvements

### DIFF
--- a/src/pages/Players.js
+++ b/src/pages/Players.js
@@ -72,13 +72,16 @@ function Players() {
           const timestamp = metadata.endTimestamp;
           const date = new Date(timestamp * 1000);
     
-          // // const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-          // const options = { year: 'numeric', month: 'long', day: 'numeric' };
-          // const formattedDate = date.toLocaleDateString('en-US', options);
-
-          // MM/DD/YY
-          const options = { year: '2-digit', month: '2-digit', day: '2-digit' };
-          const formattedDate = date.toLocaleDateString('en-US', options);
+          let formattedDate;
+          if (window.innerWidth < 600) {
+            // MM/DD/YY for mobile
+            const options = { year: '2-digit', month: '2-digit', day: '2-digit' };
+            formattedDate = date.toLocaleDateString('en-US', options);
+          } else {
+            // full date otherwise
+            const options = { year: 'numeric', month: 'long', day: 'numeric' };
+            formattedDate = date.toLocaleDateString('en-US', options);
+          }
     
           setLastUpdated(formattedDate);
         } else {

--- a/src/pages/Players.js
+++ b/src/pages/Players.js
@@ -72,8 +72,12 @@ function Players() {
           const timestamp = metadata.endTimestamp;
           const date = new Date(timestamp * 1000);
     
-          // const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-          const options = { year: 'numeric', month: 'long', day: 'numeric' };
+          // // const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+          // const options = { year: 'numeric', month: 'long', day: 'numeric' };
+          // const formattedDate = date.toLocaleDateString('en-US', options);
+
+          // MM/DD/YY
+          const options = { year: '2-digit', month: '2-digit', day: '2-digit' };
           const formattedDate = date.toLocaleDateString('en-US', options);
     
           setLastUpdated(formattedDate);

--- a/src/pages/Teams.js
+++ b/src/pages/Teams.js
@@ -29,13 +29,16 @@ function Teams() {
           const timestamp = metadata.endTimestamp;
           const date = new Date(timestamp * 1000);
 
-          // // const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-          // const options = { year: 'numeric', month: 'long', day: 'numeric' };
-          // const formattedDate = date.toLocaleDateString('en-US', options);
-
-          // MM/DD/YY
-          const options = { year: '2-digit', month: '2-digit', day: '2-digit' };
-          const formattedDate = date.toLocaleDateString('en-US', options);
+          let formattedDate;
+          if (window.innerWidth < 600) {
+            // MM/DD/YY for mobile
+            const options = { year: '2-digit', month: '2-digit', day: '2-digit' };
+            formattedDate = date.toLocaleDateString('en-US', options);
+          } else {
+            // full date otherwise
+            const options = { year: 'numeric', month: 'long', day: 'numeric' };
+            formattedDate = date.toLocaleDateString('en-US', options);
+          }
 
           setLastUpdated(formattedDate);
         } else {

--- a/src/pages/Teams.js
+++ b/src/pages/Teams.js
@@ -29,8 +29,12 @@ function Teams() {
           const timestamp = metadata.endTimestamp;
           const date = new Date(timestamp * 1000);
 
-          // const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-          const options = { year: 'numeric', month: 'long', day: 'numeric' };
+          // // const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+          // const options = { year: 'numeric', month: 'long', day: 'numeric' };
+          // const formattedDate = date.toLocaleDateString('en-US', options);
+
+          // MM/DD/YY
+          const options = { year: '2-digit', month: '2-digit', day: '2-digit' };
           const formattedDate = date.toLocaleDateString('en-US', options);
 
           setLastUpdated(formattedDate);

--- a/src/styles/Home.scss
+++ b/src/styles/Home.scss
@@ -29,7 +29,7 @@ body, html {
             min-height: 100vh;
         }
         @media (max-width: 499px) {
-            min-height: 80vh;
+            min-height: calc(0.583*100vh + 210px);
         }
         @media (max-height: 500px) and (min-width: 500px) {
             min-height: 200vh;
@@ -109,6 +109,10 @@ body, html {
                 font-size: calc(20/390 * 100vw);
                 font-weight: 300;
                 margin-top: 6%;
+
+                .headshot {
+                    margin-top: 10px;
+                }
             }
         }
     }
@@ -128,8 +132,10 @@ body, html {
         @media (max-width: 1000px) {
             max-height: none;
             height: 40%;
+            // width: 69.5%;
+            // height: auto;
             // top: 45%;
-            top: calc(88.9841% - 294px);
+            top: calc(0.276*100vh + 91px);
             transform: translate(-50%, 0%) !important;
             left: 50%;
             right: auto;


### PR DESCRIPTION
- Fixed spacing of the landing section of the home page, increasing the minimum width for mobile screens so that the headshot image does not intersect the border.
- Fixed dimensioning of the headshot image for mobile screens to center it better on the landing page vertically.
- Changed the formatting of the dates on the Players and Teams pages of the website to better fit it on the screen for mobiles screens. For screens less than 600px, it uses MM//DD/YY. Otherwise, it uses the full text for the date. This ensures that the subtitle only takes up one line of space vertically.