### PR TITLE
Fix Players Page Sorting Bug

### DIFF
--- a/src/pages/Players.js
+++ b/src/pages/Players.js
@@ -9,7 +9,10 @@ function Players() {
   const [teamFilter, setTeamFilter] = useState('');
   const [posFilter, setPosFilter] = useState('');
   const [selectedColumn, setSelectedColumn] = useState(null);
-  const [sortBy, setSortByState] = useState([]);
+  const [sortBy, setSortByState] = useState([
+    { id: 'points', desc: true },
+    { id: 'goals', desc: true }
+  ]);
   const [lastUpdated, setLastUpdated] = useState('');
 
   const columns = React.useMemo(
@@ -176,7 +179,7 @@ function Players() {
       initialState: {
         pageIndex: 0,
         pageSize: 25,
-        sortBy: sortBy.length > 0 ? sortBy : [
+        sortBy: [
           { id: 'points', desc: true },
           { id: 'goals', desc: true }
         ],
@@ -193,11 +196,12 @@ function Players() {
     const isDescending = ['games', 'goals', 'assists', 'points'].includes(column.id);
     if (selectedColumn === column.id) {
       setSelectedColumn(null);
-      setSortBy([]);
-      setSortByState([
+      const defaultSort = [
         { id: 'points', desc: true },
         { id: 'goals', desc: true }
-      ]);
+      ];
+      setSortBy(defaultSort);
+      setSortByState(defaultSort);
     } else {
       setSelectedColumn(column.id);
       const sortConfig = [


### PR DESCRIPTION
## Describe the Changes Made

- Fixed bug where when removing a sorting, the table would no longer be sorted by the player points, which should be the default.
- Included sorting criteria in state.

## Describe Any Known Errors, Issues, or Bugs

- None known.

## Describe Any Tests Done

- Functions as expected on local development server. To test deployment on this PR.
- This bug does not occur on the Teams page.

